### PR TITLE
Feat/sigma2 user roles

### DIFF
--- a/ckanext/datasetapproval/auth.py
+++ b/ckanext/datasetapproval/auth.py
@@ -2,6 +2,7 @@ import logging
 from ckan.plugins import toolkit as tk
 import ckan.authz as authz
 from ckan.logic.auth.update import package_update as core_package_update
+from ckan import model
 
 log = logging.getLogger(__name__)
 
@@ -27,9 +28,13 @@ def package_update(context, data_dict):
     # This check doesn't allow to edit dataset
     # which is in alredy in review state
     if data_dict:
+        current_user = tk.current_user
+        package_id = data_dict.get("id")
         previous_data_dict = tk.get_action("package_show")(
             context, {"id": data_dict.get("id")}
         )
+        creator_user_id = previous_data_dict.get("creator_user_id")
+
         if (
             previous_data_dict.get("state") == "inreview"
             and previous_data_dict.get("creator_user_id") == tk.current_user.id
@@ -37,6 +42,52 @@ def package_update(context, data_dict):
             return {
                 "success": False,
                 "msg": "User cannot update dataset while it is in review",
+            }
+
+        if not current_user.is_anonymous and not current_user.sysadmin:
+            # Creator can always edit
+            if creator_user_id == current_user.id:
+                return {
+                    "success": True
+                }
+
+            # Users with review permission can always edit
+            plugin_extras = current_user.plugin_extras
+            if plugin_extras:
+                user_has_review_permission = plugin_extras.get("user_has_review_permission", False)
+                if user_has_review_permission:
+                    return {
+                        "success": True
+                    }
+
+            # By default, if unowned datasets and create_dataset_if_not_in_organization
+            # are enabled, any user can update a dataset. We have to override that.
+            package_collaborators = tk.get_action("package_collaborator_list")
+            privileged_context = {
+                "ignore_auth": True,
+                "model": model
+            }
+            collaborators_list = package_collaborators(privileged_context,
+                                                       {"id": package_id})
+
+            for collaborator in collaborators_list:
+                collaborator_id = collaborator.get("user_id")
+                collaborator_capacity = collaborator.get("capacity")
+
+                # If user is collaborator with capacity admin or editor,
+                # update is allowed
+                if collaborator_id == current_user.id \
+                        and collaborator_capacity in ["admin", "editor"]:
+
+                    return {
+                        "success": True
+                    }
+
+            # If it got to that line, user doesn't have permission to
+            # update datasets
+            return {
+                "success": False,
+                "msg": "User not allowed to update this dataset",
             }
 
     return core_package_update(context, data_dict)

--- a/ckanext/datasetapproval/helpers.py
+++ b/ckanext/datasetapproval/helpers.py
@@ -1,6 +1,7 @@
 import logging
 
 from ckan.plugins import toolkit as tk
+from ckan import model
 import ckan.authz as authz
 
 
@@ -15,4 +16,23 @@ def is_dataset_owner(data_dict, user_id):
         dataset = tk.get_action("package_show")(data_dict={"id": data_dict.get("id")})
         return dataset["creator_user_id"] == user_id
     except Exception as e:
+        return False
+
+
+def is_dataset_collaborator(data_dict, user_id):
+    try:
+        context = {
+            "ignore_auth": True,
+            "model": model
+        }
+        collaborators = tk.get_action("package_collaborator_list")(context, data_dict={"id": data_dict.get("id")})
+
+        for collaborator in collaborators:
+            collaborator_id = collaborator.get('user_id')
+            if user_id == collaborator_id:
+                return True
+
+        return False
+    except Exception as e:
+        log.error(e)
         return False

--- a/ckanext/datasetapproval/plugin.py
+++ b/ckanext/datasetapproval/plugin.py
@@ -67,7 +67,11 @@ class DatasetapprovalPlugin(
 
     # IBlueprint
     def get_blueprint(self):
-        blueprints = [views.dataset.registred_views(), views.review.registred_views(), views.user.registred_views()]
+        blueprints = [
+                views.dataset.registred_views(),
+                views.review.registred_views(),
+                views.user.registred_views(),
+                views.admin.registred_views()]
         blueprints.extend(views.resource.registred_views())
         return blueprints
 

--- a/ckanext/datasetapproval/plugin.py
+++ b/ckanext/datasetapproval/plugin.py
@@ -36,7 +36,8 @@ class DatasetapprovalPlugin(
             "package_update": actions.package_update,
             "dataset_review": actions.dataset_review,
             "publish_dataset": actions.publish_dataset,
-            "org_autocomplete": actions.org_autocomplete
+            "org_autocomplete": actions.org_autocomplete,
+            "user_show": actions.user_show
         }
 
     # ITemplateHelpers
@@ -47,7 +48,7 @@ class DatasetapprovalPlugin(
 
     # IBlueprint
     def get_blueprint(self):
-        blueprints = [views.dataset.registred_views(), views.review.registred_views()]
+        blueprints = [views.dataset.registred_views(), views.review.registred_views(), views.user.registred_views()]
         blueprints.extend(views.resource.registred_views())
         return blueprints
 

--- a/ckanext/datasetapproval/plugin.py
+++ b/ckanext/datasetapproval/plugin.py
@@ -44,6 +44,7 @@ class DatasetapprovalPlugin(
     def get_helpers(self):
         return {
             "is_dataset_owner": helpers.is_dataset_owner,
+            "is_dataset_collaborator": helpers.is_dataset_collaborator,
         }
 
     # IBlueprint
@@ -65,11 +66,14 @@ class DatasetapprovalPlugin(
         if tk.current_user and tk.current_user.is_authenticated:
             user_id = tk.c.userobj.id
 
-        capacity = authz.users_role_for_group_or_org(dataset_obj.owner_org, user_id)
-        is_org_admin = capacity == "admin"
-        # Editor shouldn't be able to collaborate on a dataset
-        if dataset_obj.creator_user_id != user_id and dataset_obj.state not in [
-            "active"
-        ] and not is_org_admin:
-            return []
+        # TODO: the code below likely can be removed
+        if dataset_obj.owner_org:
+            capacity = authz.users_role_for_group_or_org(dataset_obj.owner_org, user_id)
+            is_org_admin = capacity == "admin"
+            # Editor shouldn't be able to collaborate on a dataset
+            if dataset_obj.creator_user_id != user_id and dataset_obj.state not in [
+                "active"
+            ] and not is_org_admin:
+                return []
+
         return labels

--- a/ckanext/datasetapproval/templates/admin/base.html
+++ b/ckanext/datasetapproval/templates/admin/base.html
@@ -1,0 +1,10 @@
+{% ckan_extends %}
+
+{% block content_primary_nav %}
+  {{ h.build_nav_icon('admin.index', _('Sysadmins'), icon='gavel') }}
+  {{ h.build_nav_icon('sigma2-admin.managers', _('Archive Managers'), icon='gavel') }}
+  {{ h.build_nav_icon('admin.config', _('Config'), icon='gear') }}
+  {{ h.build_nav_icon('admin.trash', _('Trash'), icon='trash') }}
+  {{ h.build_extra_admin_nav() }}
+{% endblock %}
+

--- a/ckanext/datasetapproval/templates/admin/managers.html
+++ b/ckanext/datasetapproval/templates/admin/managers.html
@@ -1,0 +1,84 @@
+{% extends "admin/base.html" %}
+
+{% block primary_content_inner %}
+  <h2>{{ _('Current Archive Managers') }}</h2>
+
+  <table class="table table-header table-hover table-bordered">
+    <thead>
+      <tr>
+        <th>{{ _('User') }}</th>
+        <th>&nbsp;</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for user in sysadmins %}
+        <tr>
+          <td>{{ h.linked_user(user) }}</td>
+          <td>
+            <div class="btn-group pull-right">
+              <form method="POST" action="{% url_for 'sigma2-admin.manager' %}">
+                {{ h.csrf_input() }}
+                <input type="hidden" value="{{ user }}" name="username" />
+                <input type="hidden" value="0" name="status" />
+                <button
+                  type="submit"
+                  class="btn btn-danger btn-sm"
+                  title="{{ _('Revoke Archive Manager permission') }}"
+                >
+                  <i class="fa fa-times"></i>
+                </button>
+              </form>
+            </div>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <hr />
+
+  <h2>{{ _('Promote user to Archive Manager') }}</h2>
+
+  <form method="POST" action="{% url_for 'sigma2-admin.manager' %}">
+    {{ h.csrf_input() }}
+    <div class="row">
+      <div class="col">
+
+        <div class="form-group">
+          <input
+            id="promote-username" type="text" name="username" placeholder="Username"
+            value="" class="control-medium" data-module="autocomplete"
+            data-module-source="/api/2/util/user/autocomplete?ignore_self=true&q=?"
+          >
+          <input type="hidden" value="1" name="status" />
+        </div>
+
+        <div class="form-actions">
+          <button
+            type="submit"
+            class="btn btn-primary"
+            title="{{ _('Promote user to Archive Manager') }}"
+          >{{ _('Promote') }}</button>
+        </div>
+
+      </div>
+    </div>
+  </form>
+{% endblock %}
+
+{% block secondary_content %}
+  <div class="module module-narrow module-shallow">
+    <h2 class="module-heading">
+      <i class="fa fa-info-circle"></i>
+      {{ _('Archive Managers') }}
+    </h2>
+    <div class="module-content">
+
+      {% set docs_url = "http://docs.ckan.org/en/{0}/sysadmin-guide.html".format(g.ckan_doc_version) %}
+      {% trans %}
+        <p>Archive managers are users that are able to see, manage and review all datasets.</p>
+      {% endtrans %}
+    </div>
+  </div>
+{% endblock %}
+

--- a/ckanext/datasetapproval/templates/header.html
+++ b/ckanext/datasetapproval/templates/header.html
@@ -1,0 +1,15 @@
+{% ckan_extends %}
+
+         {% block header_site_navigation_tabs %}
+              {% set org_type = h.default_group_type('organization') %}
+              {% set group_type = h.default_group_type('group') %}
+
+            {{ c.user_obj }}
+              {{ h.build_nav_main(
+                (dataset_type ~ '.search', h.humanize_entity_type('package', dataset_type, 'main nav') or _('Datasets'), ["dataset", "resource"]),
+                (org_type ~ '.index',
+                  h.humanize_entity_type('organization', org_type, 'main nav') or _('Organizations'), ['organization']),
+                (group_type ~ '.index',
+                  h.humanize_entity_type('group', group_type, 'main nav') or _('Groups'), ['group']),
+                ('home.about', _('About')) ) }}
+            {% endblock %}

--- a/ckanext/datasetapproval/templates/header.html
+++ b/ckanext/datasetapproval/templates/header.html
@@ -4,10 +4,9 @@
               {% set org_type = h.default_group_type('organization') %}
               {% set group_type = h.default_group_type('group') %}
 
-            {{ c.user_obj }}
               {{ h.build_nav_main(
                 (dataset_type ~ '.search', h.humanize_entity_type('package', dataset_type, 'main nav') or _('Datasets'), ["dataset", "resource"]),
-                (org_type ~ '.index',
+                ('org' ~ '.index',
                   h.humanize_entity_type('organization', org_type, 'main nav') or _('Organizations'), ['organization']),
                 (group_type ~ '.index',
                   h.humanize_entity_type('group', group_type, 'main nav') or _('Groups'), ['group']),

--- a/ckanext/datasetapproval/templates/package/read.html
+++ b/ckanext/datasetapproval/templates/package/read.html
@@ -41,7 +41,7 @@
         </a>
     </div>    
     </div>  
-    {% elif  c.pkg_dict.state == "inreview" and h.is_dataset_owner(c.pkg_dict, c.userobj.id) %}
+    {% elif  c.pkg_dict.state == "inreview" and (h.is_dataset_owner(c.pkg_dict, c.userobj.id) or h.is_dataset_collaborator(c.pkg_dict, c.userobj.id)) %}
     <div class="alert alert-warning" role="alert">
         <p>{{ _("This dataset is waiting for an administrator to review.") }}</p>    
     </div>

--- a/ckanext/datasetapproval/templates/snippets/package_item.html
+++ b/ckanext/datasetapproval/templates/snippets/package_item.html
@@ -5,7 +5,7 @@
         <span class="badge bg-info">{{ _('Draft') }}</span>
     {% elif package.get('state', '').startswith('deleted') %}
         <span class="badge bg-danger">{{ _('Deleted') }}</span>
-    {% elif package.get('state', '') == 'inreview' and  h.is_dataset_owner(package, c.userobj.id) %}
+    {% elif package.get('state', '') == 'inreview' and  (h.is_dataset_owner(package, c.userobj.id) or h.is_dataset_collaborator(package, c.userobj.id)) %}
         <span class="badge bg-warning">{{ _('In review') }}</span>
     {% elif package.get('state', '') in ['inreview', 'pending'] %}
         <span class="badge bg-warning">{{ _('Pending') }}</span>

--- a/ckanext/datasetapproval/templates/user/edit_user_form.html
+++ b/ckanext/datasetapproval/templates/user/edit_user_form.html
@@ -1,0 +1,24 @@
+{% ckan_extends %}
+
+{% set user_is_sysadmin = h.check_access('sysadmin') %}
+{% set user_has_review_permission = data.user_has_review_permission %}
+
+<!-- Users who are not sysadmin cannot modify this field -->
+{% set attrs = {"disabled": "disabled"} if not user_is_sysadmin else {} %}
+
+{% block extra_fields %}
+    <!-- Only users with review permission or sysadmin can see this field -->
+    <!-- It won't show on the sysadmin's edit form -->
+    {% if (user_has_review_permission or user_is_sysadmin) and not data.sysadmin %}
+        {% call form.checkbox('user_has_review_permission', label=_('User has review permission'), 
+            id='field-user-has-review-permission', value=True, checked=user_has_review_permission, 
+            attrs=attrs) %}
+            {% set helper_text = _("Allow the user to see, manage and review all datasets.") %}
+            {{ form.info(helper_text) }}
+        {% endcall %}
+    {% endif %}
+
+    {{ super() }}
+{% endblock %}
+
+

--- a/ckanext/datasetapproval/views/__init__.py
+++ b/ckanext/datasetapproval/views/__init__.py
@@ -1,3 +1,3 @@
-from ckanext.datasetapproval.views import dataset, resource, review, user
+from ckanext.datasetapproval.views import dataset, resource, review, user, admin
 
-__all__ = [dataset, resource, review, user]
+__all__ = [dataset, resource, review, user, admin]

--- a/ckanext/datasetapproval/views/__init__.py
+++ b/ckanext/datasetapproval/views/__init__.py
@@ -1,3 +1,3 @@
-from ckanext.datasetapproval.views import dataset, resource, review
+from ckanext.datasetapproval.views import dataset, resource, review, user
 
-__all__ = [dataset, resource, review]
+__all__ = [dataset, resource, review, user]

--- a/ckanext/datasetapproval/views/admin.py
+++ b/ckanext/datasetapproval/views/admin.py
@@ -1,0 +1,75 @@
+import logging
+
+from flask import Blueprint
+import sqlalchemy
+import ckan.model as model
+import ckan.lib.base as base
+from ckan.common import request, asbool, current_user, _
+from typing import cast, Any
+from ckan.types import Context, Schema, Response
+import ckan.logic as logic
+from ckan.lib.helpers import helper_functions as h
+
+
+log = logging.getLogger(__name__)
+
+admin = Blueprint("sigma2-admin", __name__, url_prefix="/ckan-admin")
+
+
+def _get_managers():
+    q = model.Session.query(model.User).filter(
+        model.User.plugin_extras.op("->>")("user_has_review_permission").cast(sqlalchemy.Boolean) == True,
+        model.User.state == u'active')
+
+    return q
+
+
+def managers() -> str:
+    data = dict(sysadmins=[a.name for a in _get_managers()])
+    return base.render(u'admin/managers.html', extra_vars=data)
+
+
+def manager():
+    username = request.form.get(u'username')
+    status = asbool(request.form.get(u'status'))
+
+    try:
+        context = cast(Context, {
+            u'model': model,
+            u'session': model.Session,
+            u'user': current_user.name,
+            u'auth_user_obj': current_user,
+        })
+        data_dict: dict[str, Any] = {u'id': username, u'plugin_extras': { "user_has_review_permission": status }}
+        user = logic.get_action(u'user_patch')(context, data_dict)
+    except logic.NotAuthorized:
+        return base.abort(
+            403,
+            _(u'Not authorized to promote user to archive manager')
+        )
+    except logic.NotFound:
+        return base.abort(404, _(u'User not found'))
+
+    if status:
+        h.flash_success(
+            _(u'Promoted {} to archive manager'.format(user[u'display_name']))
+        )
+    else:
+        h.flash_success(
+            _(
+                u'Revoked archive manager permission from {}'.format(
+                    user[u'display_name']
+                )
+            )
+        )
+    return h.redirect_to(u'sigma2-admin.managers')
+
+
+admin.add_url_rule(
+    u'/managers', view_func=managers, methods=['GET'], strict_slashes=False
+)
+admin.add_url_rule(rule=u'/manager', view_func=manager, methods=['POST'])
+
+
+def registred_views():
+    return admin

--- a/ckanext/datasetapproval/views/user.py
+++ b/ckanext/datasetapproval/views/user.py
@@ -1,0 +1,69 @@
+# encoding: utf-8
+import logging
+
+from flask import Blueprint
+from ckan.views.user import (
+    EditView as BaseEditView,
+)
+from ckan import logic
+import ckan.lib.navl.dictization_functions as dictization_functions
+from ckan.common import (
+    _, config, g, request, current_user, login_user, logout_user, session
+)
+import ckan.lib.base as base
+from ckan.plugins import toolkit as tk
+
+log = logging.getLogger(__name__)
+
+user = Blueprint(
+    "approval_user",
+    __name__,
+    url_prefix="/user"
+)
+
+# TODO: register view?
+
+
+class EditView(BaseEditView):
+    def __init__(self):
+        log.error("heya")
+        super().__init__()
+
+    def get(self, id, data = None, errors = None, error_summary = None):
+        log.error("######")
+        log.error(data)
+        return super().get(id, data, errors, error_summary)
+
+    def post(self, id):
+        context, id = self._prepare(id)
+        if not context[u'save']:
+            return self.get(id)
+
+        try:
+            data_dict = logic.clean_dict(
+                dictization_functions.unflatten(
+                    logic.tuplize_dict(logic.parse_params(request.form))))
+
+        except dictization_functions.DataError:
+            base.abort(400, _(u'Integrity Error'))
+
+        if current_user.sysadmin:
+            # Only allow to update the review permission if requester
+            # is sysadmin
+            has_review_permission = data_dict.get("user_has_review_permission", False)
+            user_name = data_dict.get("name")
+            plugin_extras = {"user_has_review_permission": has_review_permission != False}
+            patch_data_dict = {
+                "id": user_name,
+                "plugin_extras": plugin_extras
+            }
+            tk.get_action("user_patch")(context, patch_data_dict)
+
+        return super().post(id)
+
+
+user.add_url_rule("/edit/<id>", view_func=EditView.as_view(str("edit")))
+
+
+def registred_views():
+    return user


### PR DESCRIPTION
## Changes 

- Sysadmins can now grant users review permission (although it's not effective yet)
- Fix package_update permissions for all roles, including collaborators
- Ensure that collaborators have a similar view as dataset owners
- New admin tab for Archive Managers management (c.f. sysadmins)