### PR TITLE
Sigma2: fix archive manager permissions

### DIFF
--- a/ckanext/datasetapproval/plugin.py
+++ b/ckanext/datasetapproval/plugin.py
@@ -11,6 +11,7 @@ from ckan.lib.plugins import DefaultPermissionLabels
 
 from ckanext.datasetapproval import views
 from ckanext.datasetapproval.actions import get_dataset_schema
+from ckan import logic
 
 log = logging.getLogger(__name__)
 
@@ -82,8 +83,24 @@ class DatasetapprovalPlugin(
             "package_update": auth.package_update,
         }
 
+    def get_user_dataset_labels(self, user_obj):
+        labels = super(DatasetapprovalPlugin, self).get_user_dataset_labels(user_obj)
+
+        user_has_review_permission = False
+        plugin_extras = user_obj.plugin_extras
+        if plugin_extras:
+            user_has_review_permission = plugin_extras.get("user_has_review_permission", False)
+
+        if user_has_review_permission:
+            labels.append("review-permission")
+
+        return labels
+
     def get_dataset_labels(self, dataset_obj):
         labels = super(DatasetapprovalPlugin, self).get_dataset_labels(dataset_obj)
+
+        labels.append("review-permission")
+
         user_id = None
         if tk.current_user and tk.current_user.is_authenticated:
             user_id = tk.c.userobj.id

--- a/ckanext/datasetapproval/templates/snippets/package_item.html
+++ b/ckanext/datasetapproval/templates/snippets/package_item.html
@@ -7,7 +7,7 @@
         <span class="badge bg-danger">{{ _('Deleted') }}</span>
     {% elif package.get('state', '') == 'inreview' and  (h.is_dataset_owner(package, c.userobj.id) or h.is_dataset_collaborator(package, c.userobj.id)) %}
         <span class="badge bg-warning">{{ _('In review') }}</span>
-    {% elif package.get('state', '') in ['inreview', 'pending'] %}
+    {% elif package.get('state', '') in ['inreview', 'pending'] or h.check_access("dataset_review", {"dataset_id": package.id}) %}
         <span class="badge bg-warning">{{ _('Pending') }}</span>
     {% elif package.get('state', '') == 'rejected' %}
         <span class="badge bg-danger">{{ _('Rejected') }}</span>

--- a/ckanext/datasetapproval/views/review.py
+++ b/ckanext/datasetapproval/views/review.py
@@ -13,6 +13,7 @@ import ckan.lib.helpers as h
 from ckan.plugins import toolkit as tk
 from ckan.views.dataset import url_with_params
 from ckan.views.user import _extra_template_variables
+from ckan import logic
 
 blueprint = Blueprint(
     "approval",
@@ -70,6 +71,13 @@ class DatasetReviewView(MethodView):
 
         extra_vars = _extra_template_variables(context, data_dict)
 
+        try:
+            user_has_review_permission = tk.check_access("dataset_review", context, None)
+        except logic.NotAuthorized:
+            user_has_review_permission = False
+
+        if user_has_review_permission:
+            context["ignore_auth"] = True
         dataset_result = tk.get_action("package_search")(context, search_dict)
 
         extra_vars["user_dict"].update(


### PR DESCRIPTION
**Related to:** https://github.com/datopian/client-sigma2-shared/issues/182

## Changes

- Ensure archive managers can view any dataset
- Ensure archive managers can approve and reject datasets